### PR TITLE
Add optional base theme module for shadcn/ui components

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,40 @@ export function MyComponent() {
 }
 ```
 
+## Theming
+
+shadcn/ui components require CSS variables to function correctly. These variables define colors, spacing, radii, and other design tokens that components use for consistent styling.
+
+### Using the Default Theme
+
+This package includes a default theme for quick prototyping. To use it, import the theme module in your application:
+
+```tsx
+import '@isofucius/deno-shadcn-ui/default/themes/base'
+```
+
+This will include the base CSS with all necessary CSS variables when your application is bundled with Vite.
+
+### Why a Separate Import?
+
+Deno's runtime doesn't support importing CSS files directly. To work around this limitation while maintaining compatibility with Deno's toolchain, we use a custom `@deno-vite-import` directive that gets transformed during the Vite build process. This approach:
+
+- Keeps your code compatible with Deno's LSP, testing, and other tools
+- Allows CSS to be properly bundled when building with Vite
+- Follows the "import only what you need" philosophy - the theme is completely optional
+
+For a complete Vite + Deno setup that supports this pattern, see [@isofucius/deno-vite-plus](https://jsr.io/@isofucius/deno-vite-plus).
+
+### Custom Themes
+
+The default theme is intended for quick prototyping. For production applications, you should create your own theme:
+
+1. Copy the contents of `src/default/themes/base.css` as a starting point
+2. Modify the CSS variables to match your design system
+3. Import your custom CSS file instead of the default theme
+
+The CSS variables follow shadcn/ui's theming system, supporting both light and dark modes with semantic color tokens.
+
 ## Repository Setup (For Maintainers)
 
 This repository syncs components from the official shadcn/ui repository and adapts them for Deno's module system. Here's how the repository works:

--- a/deno.json
+++ b/deno.json
@@ -141,6 +141,7 @@
     "./default/ui/skeleton": "./src/default/ui/skeleton.tsx",
     "./default/ui/context-menu": "./src/default/ui/context-menu.tsx",
     "./default/ui/form": "./src/default/ui/form.tsx",
-    "./default/ui/carousel": "./src/default/ui/carousel.tsx"
+    "./default/ui/carousel": "./src/default/ui/carousel.tsx",
+    "./default/themes/base": "./src/default/themes/base.ts"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@isofucius/deno-shadcn-ui",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publish": {
     "include": [
       "LICENSE",

--- a/src/default/themes/base.css
+++ b/src/default/themes/base.css
@@ -1,0 +1,124 @@
+@import 'tailwindcss';
+
+@plugin 'tailwindcss-animate';
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --radius: 0.625rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.145 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.145 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.396 0.141 25.723);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --ring: oklch(0.439 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-ring: oklch(0.439 0 0);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/src/default/themes/base.ts
+++ b/src/default/themes/base.ts
@@ -1,42 +1,42 @@
 /**
  * Default theme for shadcn/ui components - provides essential CSS variables for quick prototyping.
- * 
+ *
  * This module uses a custom @deno-vite-import directive to include CSS while maintaining Deno compatibility.
  * Deno's runtime doesn't support importing CSS files directly, which would cause errors during development,
  * testing, or running TypeScript code. The @deno-vite-import directive is processed by a custom Vite plugin
  * that transforms it into a proper CSS import during the build process, allowing you to:
  * - Use Deno's native toolchain (LSP, testing, etc.) without errors
  * - Bundle CSS correctly when building with Vite
- * 
+ *
  * For a complete working setup with Vite and Deno, see: https://jsr.io/@isofucius/deno-vite-plus
- * 
+ *
  * ## Usage
- * 
+ *
  * Import this module in your app to include the default shadcn/ui theme:
  * ```ts
  * import '@isofucius/deno-shadcn-ui/default/themes/base'
  * ```
- * 
+ *
  * When processed by Vite with the deno-vite-plugin, this will bundle the base.css file containing
  * all necessary CSS variables that shadcn/ui components depend on for styling.
- * 
+ *
  * ## Why CSS Variables?
- * 
+ *
  * shadcn/ui components rely on CSS custom properties (variables) for theming. These variables define
  * colors, spacing, radii, and other design tokens that components reference. Without these variables,
  * components will lack proper styling and may not display correctly.
- * 
+ *
  * ## Customization
- * 
+ *
  * This default theme is intended for quick prototyping. For production applications, you're encouraged
  * to create your own theme by:
  * 1. Copying the base.css file as a starting point
  * 2. Modifying the CSS variables to match your design system
  * 3. Importing your custom theme instead of this default one
- * 
+ *
  * This package follows a "import only what you need" philosophy. If you don't want to use the default
  * theme, simply don't import this module and provide your own CSS variables instead.
- * 
+ *
  * @module
  */
 

--- a/src/default/themes/base.ts
+++ b/src/default/themes/base.ts
@@ -1,0 +1,47 @@
+/**
+ * Default theme for shadcn/ui components - provides essential CSS variables for quick prototyping.
+ * 
+ * This module uses a custom @deno-vite-import directive to include CSS while maintaining Deno compatibility.
+ * Deno's runtime doesn't support importing CSS files directly, which would cause errors during development,
+ * testing, or running TypeScript code. The @deno-vite-import directive is processed by a custom Vite plugin
+ * that transforms it into a proper CSS import during the build process, allowing you to:
+ * - Use Deno's native toolchain (LSP, testing, etc.) without errors
+ * - Bundle CSS correctly when building with Vite
+ * 
+ * For a complete working setup with Vite and Deno, see: https://jsr.io/@isofucius/deno-vite-plus
+ * 
+ * ## Usage
+ * 
+ * Import this module in your app to include the default shadcn/ui theme:
+ * ```ts
+ * import '@isofucius/deno-shadcn-ui/default/themes/base'
+ * ```
+ * 
+ * When processed by Vite with the deno-vite-plugin, this will bundle the base.css file containing
+ * all necessary CSS variables that shadcn/ui components depend on for styling.
+ * 
+ * ## Why CSS Variables?
+ * 
+ * shadcn/ui components rely on CSS custom properties (variables) for theming. These variables define
+ * colors, spacing, radii, and other design tokens that components reference. Without these variables,
+ * components will lack proper styling and may not display correctly.
+ * 
+ * ## Customization
+ * 
+ * This default theme is intended for quick prototyping. For production applications, you're encouraged
+ * to create your own theme by:
+ * 1. Copying the base.css file as a starting point
+ * 2. Modifying the CSS variables to match your design system
+ * 3. Importing your custom theme instead of this default one
+ * 
+ * This package follows a "import only what you need" philosophy. If you don't want to use the default
+ * theme, simply don't import this module and provide your own CSS variables instead.
+ * 
+ * @module
+ */
+
+// @deno-vite-import ./base.css
+
+const dummy = 'dummy'
+
+export default dummy


### PR DESCRIPTION
## Summary
- Adds an optional base theme module that users can import for quick prototyping
- Theme is completely opt-in - only loaded when explicitly imported

## Implementation Details

### What Changed
- Moved existing `styles.css` to `src/default/themes/base.css`
- Created `src/default/themes/base.ts` module with `@deno-vite-import` directive
- Updated `build-exports.ts` to scan and export themes directory
- Added comprehensive module documentation explaining Deno's CSS import restrictions
- Added Theming section to README with usage instructions

### Usage
Users can now optionally import the base theme:
```tsx
import '@isofucius/deno-shadcn-ui/default/themes/base'
```

This maintains the package's "import only what you need" philosophy while providing a convenient default theme for prototyping.

## Related
- Linear Issue: [AXE-137](https://linear.app/paideia-copilot/issue/AXE-137/add-shadcn-base-themes-to-shadcn-package)
- Uses [@isofucius/deno-vite-plus](https://jsr.io/@isofucius/deno-vite-plus) for Vite integration

🤖 Generated with [Claude Code](https://claude.ai/code)